### PR TITLE
Fixing issue for quokka/gizmo compute nodes

### DIFF
--- a/epam/models.py
+++ b/epam/models.py
@@ -526,7 +526,16 @@ class TorchModel(BaseModel):
 
         """
         super().__init__(model_name=model_name)
-        if torch.backends.cudnn.is_available():
+
+        # check that CUDA is usable
+        def check_CUDA():
+            try:
+                torch._C._cuda_init()
+                return True
+            except:
+                return False
+
+        if torch.backends.cudnn.is_available() and check_CUDA():
             print("Using CUDA")
             self.device = torch.device("cuda")
         elif torch.backends.mps.is_available():


### PR DESCRIPTION
Forces CPU usage when NVIDIA driver is out-of-date; ESM/torch models now working on gizmo and quokka compute nodes