### PR TITLE
Avoid casting family to int

### DIFF
--- a/epam/oe_plot.py
+++ b/epam/oe_plot.py
@@ -1495,7 +1495,16 @@ def get_numbering_dict(anarci_path, pcp_df=None, verbose=False, checks="imgt"):
 
     for i, row in anarci_df.iterrows():
         # assumes clonal family ID has format "{sample_id}|{family}|{seq_name}"
-        [sample_id, family, seq_name] = row["Id"].split("|")
+        cfinfos = row["Id"].split("|")
+        sample_id = cfinfos[0]
+        # try-block to cast family ID to integer if appropriate
+        try: 
+            int(cfinfos[1])
+        except ValueError:
+            family = cfinfos[1]
+        else:
+            family = int(cfinfos[1])
+
         seqlist = [row[col] for col in numbering_cols]
         numbering = [nn for nn, aa in zip(numbering_cols, seqlist) if aa != "-"]
 


### PR DESCRIPTION
This PR is required for validation with `pcp_df`-format data containing paired sequences.
It is required for https://github.com/matsengrp/dnsm-experiments-1/pull/84