### PR TITLE
Update snakemake install

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@
 
 The environment can be set up with [Mamba](https://github.com/mamba-org/mamba). Create the environment and install relevant packages as follows:
 
-    conda create -n epam python=3.11
-    conda activate epam
-    conda install datrie
+    mamba create -n epam python=3.11
+    mamba activate epam
     make install
 
 The `netam` package needs to be installed within the epam conda environment (though outside the epam file directory). Separately clone the repository (https://github.com/matsengrp/netam), checkout the relevant version of the repo `git checkout 22c8873`, and run `make install`.

--- a/notebooks/write_gcreplay_overlap_csv.py
+++ b/notebooks/write_gcreplay_overlap_csv.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np
 import pandas as pd
 from epam.oe_plot import (

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ fair-esm==2.0.0
 h5py==3.12.1
 numpy==2.0.2
 pytest==8.3.4
-snakemake==8.25.5
+snakemake==9.21.0
 tensorboardX==2.6.2.2
 torch==2.5.1
 typing_extensions==4.12.2


### PR DESCRIPTION
- update requirements to pin to snakemake 9.21.0, so that datrie is no longer a dependency
- install instructions in README updated accordingly